### PR TITLE
change button to link on boards index

### DIFF
--- a/lib/todo_web/templates/board/index.html.eex
+++ b/lib/todo_web/templates/board/index.html.eex
@@ -4,7 +4,7 @@
   <div class="flex justify-center flex-wrap w-9/12 mt-12">
     <%= for board <- @boards do %>
       <div class="w-full px-2 md:w-1/4 mb-4 h-32 max-w">
-        <%= button(board.name, to: "/boards/#{board.id}", method: :get, class: "hover:bg-gray-100 w-full h-full bg-white shadow-lg rounded-lg flex items-center justify-center px-2 text-gray-800 text-xl text-center font-semibold text-align") %>
+        <%= link(board.name, to: "/boards/#{board.id}", method: :get, class: "hover:bg-gray-100 w-full h-full bg-white shadow-lg rounded-lg flex items-center justify-center px-2 text-gray-800 text-xl text-center font-semibold text-align") %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
### Overview

If I use `button` instead of `link` it will include `csrf_token=&_method=get` in the params when clicking on a board.